### PR TITLE
73-prioritized-rerouting-to-node-from-higher-energy-profile

### DIFF
--- a/lib/painlessMesh/src/painlessmesh/mesh.hpp
+++ b/lib/painlessMesh/src/painlessmesh/mesh.hpp
@@ -135,7 +135,7 @@ namespace painlessmesh {
                         auto txThreshold = energyProfiles.at(energyProfile).first;
                         auto rxThreshold = energyProfiles.at(energyProfile).second;
                         Pear::getInstance().pearNodeTreeMap.insert({
-                            chipId, std::make_shared<PearNodeTree>(chipId, txThreshold, rxThreshold)
+                            chipId, std::make_shared<PearNodeTree>(chipId, txThreshold, rxThreshold, energyProfile)
                         });
                     }
                 }

--- a/lib/painlessMesh/src/painlessmesh/pear.hpp
+++ b/lib/painlessMesh/src/painlessmesh/pear.hpp
@@ -22,7 +22,7 @@ namespace painlessmesh {
         std::list<std::shared_ptr<PearNodeTree> > parentCandidates;
         int txThreshold = 38;
         int rxThreshold = 8;
-        int energyProfile = (txThreshold + rxThreshold) / 2;
+        int energyProfile = 999; // Initialised as 999 to indicate it hasn't been set.
 
         // Define the < operator for comparison
         bool operator<(const PearNodeTree &other) const {
@@ -63,11 +63,12 @@ namespace painlessmesh {
             this->rxThreshold = rxThreshold;
         }
 
-        PearNodeTree(const uint32_t nodeId, const int txThreshold, const int rxThreshold) {
+        PearNodeTree(const uint32_t nodeId, const int txThreshold, const int rxThreshold, const int energyProfile) {
             this->nodeId = nodeId;
             this->root = false;
             this->txThreshold = txThreshold;
             this->rxThreshold = rxThreshold;
+            this->energyProfile = energyProfile;
         }
     };
 


### PR DESCRIPTION
Added <= check of new parent candidates energy profile. Making sure we're connecting to a new node of same or higher energy profile.